### PR TITLE
[SSL-259] added eslint no-unused-vars rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,5 +21,6 @@ module.exports = {
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
   },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,6 +21,10 @@ module.exports = {
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
-    '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+    '@typescript-eslint/no-unused-vars': ['error', { 
+      argsIgnorePattern: "^_",
+      varsIgnorePattern: "^_",
+      caughtErrorsIgnorePattern: "^_"
+    }],
   },
 };


### PR DESCRIPTION
## Issue Description

Based on [this discussion](https://github.com/luxurypresence/identity-service/pull/24#discussion_r1029874531), we agreed to update the `@typescript-eslint/no-unused-vars` rule to report as an error. We should update the lint rule in all our repos.

## Issue Tickets

https://luxurypresence.atlassian.net/browse/SSL-259

## Test Plan

Try to add an unused import to a file and check that the editor will show an error. Additionally, you can try to create a commit with that and check that it will fail.
