### PR TITLE
[SSL-561] Support Plunk's V2 endpoint

### DIFF
--- a/lib/dtos/address.dto.ts
+++ b/lib/dtos/address.dto.ts
@@ -1,12 +1,15 @@
 export interface Address {
-  streetPreDirection: string;
-  streetPostDirection: string;
-  secondaryDesignator: string;
+  parcelId: string;
+  fips: string;
+  apn: string;
+  alternateApn: string;
   primaryNumber: string;
+  streetPreDirection: string;
   streetName: string;
   streetSuffix: string;
+  streetPostDirection: string;
+  secondaryDesignator: string;
   secondaryNumber: string;
-  parcelId: string;
   cityName: string;
   stateCode: string;
   zipCode: string;

--- a/lib/dtos/valuation.dto.ts
+++ b/lib/dtos/valuation.dto.ts
@@ -1,6 +1,6 @@
 export class Valuation {
-  appreciationPerSecond: number;
-  valueDate: string;
-  valueDollars: number;
   parcelId: string;
+  valuationDollars: number;
+  valuationTimestamp: string;
+  appreciationPerSecond: number;
 }

--- a/lib/plunk.constants.ts
+++ b/lib/plunk.constants.ts
@@ -2,5 +2,5 @@ export const PLUNK_MODULE_OPTIONS = 'PLUNK_MODULE_OPTIONS';
 export const PLUNK_API_HEADER_NAME = 'X-API-Key';
 export const PLUNK_API_URL = 'https://api.getplunk.com/homevalue';
 export const PLUNK_ADDRESS_SEARCH_URL = `${PLUNK_API_URL}/addresses/search`;
-export const PLUNK_HOME_VALUATION_URL = `${PLUNK_API_URL}/valuations`;
+export const PLUNK_HOME_VALUATION_URL = `${PLUNK_API_URL}/v2/valuations`;
 export const PLUNK_ADDRESS_SEARCH_PARAM = 'address';

--- a/lib/plunk.service.ts
+++ b/lib/plunk.service.ts
@@ -42,7 +42,9 @@ export class PlunkService {
     };
   }
 
-  async getHomeValuationByParcelId(parcelId: string): Promise<Valuation> {
+  async getHomeValuationByParcelId(
+    parcelId: string
+  ): Promise<Valuation | never> {
     const { data } = await firstValueFrom(
       this.httpService.get(`${PLUNK_HOME_VALUATION_URL}/${parcelId}`, {
         ...this.requestOptions,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@luxury-presence/nestjs-plunk",
-  "version": "1.0.0",
+  "version": "2.0.0-alpha.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@luxury-presence/nestjs-plunk",
-      "version": "1.0.0",
+      "version": "2.0.0-alpha.0",
       "license": "MIT",
       "devDependencies": {
         "@nestjs/axios": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxury-presence/nestjs-plunk",
-  "version": "1.0.1",
+  "version": "2.0.0-alpha.0",
   "description": "Plunk module for Nest based on the plunk api package.",
   "keywords": [
     "nestjs",


### PR DESCRIPTION
- New major version of the library.
- Update DTOs with updated responses.
- Use V2 of Plunk's valuation API.

---

Plunk API documentation for V2 [can be found here](https://api.getplunk.com/homevalue/openapi) for reference.